### PR TITLE
Convert pg `date` type to `string` instead of `Date` in JavaScript

### DIFF
--- a/src/lib/components/book/BookTable.svelte
+++ b/src/lib/components/book/BookTable.svelte
@@ -4,8 +4,8 @@
 
 	interface BookTableType extends BookInfo {
 		added_date?: Date;
-		finish_date?: Date;
-		start_date?: Date;
+		finish_date?: string;
+		start_date?: string;
 		label_name?: string;
 	}
 	export let books: BookTableType[];
@@ -35,10 +35,10 @@
 					{#if extended}
 						<td>{book.label_name ?? 'N/A'}</td>
 						<td>{convertDate(book.added_date)}</td>
-						<td>{convertDate(book.start_date)}</td>
-						<td>{convertDate(book.finish_date)}</td>
+						<td>{book.start_date}</td>
+						<td>{book.finish_date}</td>
 					{:else}
-						<td>{convertDate(book.release_date)}</td>
+						<td>{book.release_date}</td>
 					{/if}
 				</tr>
 			{/each}

--- a/src/lib/components/book/book-card/BookCardSimple.svelte
+++ b/src/lib/components/book/book-card/BookCardSimple.svelte
@@ -2,7 +2,6 @@
 	import type { BookInfo } from '$lib/types/dbTypes';
 	import { PUBLIC_IMAGE_URL } from '$env/static/public';
 	import Icon from '$lib/components/icon/Icon.svelte';
-	import { convertDate } from '$lib/util/convertDate';
 
 	export let book: BookInfo;
 </script>
@@ -45,7 +44,7 @@
 			<div class="icon-text justify-end">
 				<Icon height="20" width="20" name="calendarRange" />
 				<p>
-					{convertDate(book.release_date)}
+					{book.release_date}
 				</p>
 			</div>
 		</div>

--- a/src/lib/components/release/ReleaseCard.svelte
+++ b/src/lib/components/release/ReleaseCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { BookRelease } from '$lib/types/dbTypes';
 	import Icon from '$lib/components/icon/Icon.svelte';
-	import { convertDate } from '$lib/util/convertDate';
 
 	export let bookRelease: BookRelease;
 </script>
@@ -19,7 +18,7 @@
 		</div>
 		<div class="card-item">
 			<Icon height="24" width="24" name="calendarRange" />
-			<p title="Release date">{convertDate(bookRelease.release_date)}</p>
+			<p title="Release date">{bookRelease.release_date}</p>
 		</div>
 		<div class="card-item">
 			<Icon height="24" width="24" name="bookOpen" />

--- a/src/lib/server/lucia.ts
+++ b/src/lib/server/lucia.ts
@@ -4,8 +4,12 @@ import { DATABASE_URL } from '$env/static/private';
 import kysely from '@lucia-auth/adapter-kysely';
 import { Kysely, PostgresDialect } from 'kysely';
 import pkg from 'pg';
-const { Pool } = pkg;
+const { types, Pool } = pkg;
 import type { DB } from '$lib/types/dbTypes';
+
+types.setTypeParser(types.builtins.DATE, (value: string) => {
+	return value;
+});
 
 export const db = new Kysely<DB>({
 	dialect: new PostgresDialect({

--- a/src/lib/types/dbTypes.ts
+++ b/src/lib/types/dbTypes.ts
@@ -8,6 +8,8 @@ export type BigIntColumnType = ColumnType<bigint | number>;
 
 export type Timestamp = ColumnType<Date, Date | string | RawBuilder, Date | string | RawBuilder>;
 
+export type DateString = ColumnType<string, Date | string | RawBuilder, Date | string | RawBuilder>;
+
 export type BookFormat = 'digital' | 'print';
 
 export type Language = 'en' | 'jp';
@@ -30,9 +32,9 @@ export interface User {
 export interface Reads {
 	added_date: Timestamp | null;
 	book_id: number;
-	finish_date: Timestamp | null;
+	finish_date: DateString | null;
 	reader_id: number;
-	start_date: Timestamp | null;
+	start_date: DateString | null;
 }
 
 export interface Book {
@@ -42,7 +44,7 @@ export interface Book {
 	cover_image_file_name: string | null;
 	description: string | null;
 	id: number;
-	release_date: Timestamp | null;
+	release_date: DateString | null;
 	title: string;
 	title_romaji: string | null;
 	volume: string | null;
@@ -55,7 +57,7 @@ export interface BookInfo {
 	volume: string | null;
 	description: string | null;
 	cover_image_file_name: string | null;
-	release_date: Date | null;
+	release_date: string | null;
 	publisher: { id: number; name: string }[];
 	authors: { id: number; name: string }[];
 	artists: { id: number; name: string }[];
@@ -125,7 +127,7 @@ export interface Release {
 	lang: Language;
 	name: string;
 	name_romaji: string | null;
-	release_date: Timestamp | null;
+	release_date: DateString | null;
 }
 
 export interface BookReleaseRel {

--- a/src/lib/util/convertDate.ts
+++ b/src/lib/util/convertDate.ts
@@ -1,7 +1,3 @@
-function padStartNumber(num: number) {
-	return String(num).padStart(2, '0');
-}
-
 export function convertDate(date: Date | null | undefined, returnNull?: boolean) {
 	if (!date) {
 		if (returnNull) {
@@ -9,7 +5,5 @@ export function convertDate(date: Date | null | undefined, returnNull?: boolean)
 		}
 		return 'N/A';
 	}
-	return `${date.getFullYear()}-${padStartNumber(date.getMonth() + 1)}-${padStartNumber(
-		date.getDate()
-	)}`;
+	return date.toISOString().substring(0, 10);
 }

--- a/src/routes/book/[id=integer]/[[title]]/+page.svelte
+++ b/src/routes/book/[id=integer]/[[title]]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { PUBLIC_IMAGE_URL } from '$env/static/public';
-	import { convertDate } from '$lib/util/convertDate';
 	import Box from '$lib/components/box/Box.svelte';
 	import ReleaseCard from '$lib/components/release/ReleaseCard.svelte';
 	import BookImageContainer from '$lib/components/book/book-image/BookImageContainer.svelte';
@@ -22,8 +21,8 @@
 				title: data.book.title,
 				cover_image_file_name: data.book.cover_image_file_name
 			},
-			startDate: convertDate(data.readingStatusResult.start_date, true),
-			finishDate: convertDate(data.readingStatusResult.finish_date, true),
+			startDate: data.readingStatusResult.start_date,
+			finishDate: data.readingStatusResult.finish_date,
 			status: data.readingStatusResult.label_name
 		});
 	};
@@ -81,8 +80,9 @@
 					{#each data.book.publisher as publisher (publisher.id)}
 						<Box text={publisher.name} href={`/publisher/${publisher.id}`} icon={'homeCity'} />
 					{/each}
-					<Box text={convertDate(data.book.release_date)} href={null} icon={'calendarRange'} />
+					<Box text={data.book.release_date} href={null} icon={'calendarRange'} />
 					<Box text={String(data.book.volume)} href={null} icon={'bookOpenPage'} />
+					<Box text={'Edit'} href={`/book/${$page.params.id}/edit`} icon={'pencil'} />
 				</div>
 				<p class="max-w-3xl">
 					{@html data.book.description}

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
 	const { count } = db.fn;
 
-	const readPerMonthPromise = sql<{ date: Date; count: string }>`
+	const readPerMonthPromise = sql<{ date: string; count: string }>`
 	SELECT date_trunc('month', gs)::date AS date, COALESCE(COUNT(book_id), 0) AS count FROM
 		generate_series(date_trunc('month', 'now'::date)::date - '11 month'::interval, date_trunc('month', 'now'::date)::date, interval '1 month') AS gs
 		LEFT JOIN

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { convertDate } from '$lib/util/convertDate';
 	import type { PageData } from './$types';
 	import {
 		Chart,
@@ -47,7 +46,7 @@
 	};
 
 	const readPerMonth = data.readPerMonth.map((row) => {
-		const [year, month] = convertDate(row.date)!.split('-');
+		const [year, month] = row.date.split('-');
 		return { date: `${year}-${month}`, count: Number(row.count) };
 	});
 

--- a/src/routes/release/[id=integer]/[[name]]/+page.svelte
+++ b/src/routes/release/[id=integer]/[[name]]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { convertDate } from '$lib/util/convertDate';
 	import BookView from '$lib/components/book/BookView.svelte';
 	import type { PageData } from './$types';
 
@@ -23,7 +22,7 @@
 				<p>Description: {data.release.description ?? 'N/A'}</p>
 				<p>Language: {data.release.lang}</p>
 				<p>ISBN13: {data.release.isbn13 ?? 'N/A'}</p>
-				<p>Release Date: {convertDate(data.release.release_date)}</p>
+				<p>Release Date: {data.release.release_date}</p>
 				<p>Format: {data.release.format}</p>
 				<p>
 					Publishers:


### PR DESCRIPTION
pg returns database type `date` as `Date` in JavaScript. This means each date is given a timezone from the server or the client. This behavior is undesired since if the client and server are in different time zones, the date will not match. For example, the date "2022-01-20" on the server might be displayed as "2022-01-19" on the client due to different time zones.

This PR makes pg return database type `date` as `string` in JavaScript to prevent the above issue.