### PR TITLE
Focus sidebar close button after opening sidebar

### DIFF
--- a/src/lib/components/sidebar/Sidebar.svelte
+++ b/src/lib/components/sidebar/Sidebar.svelte
@@ -2,30 +2,18 @@
 	import SidebarItem from '$lib/components/sidebar/SidebarItem.svelte';
 	import SidebarHeading from '$lib/components/sidebar/SidebarHeading.svelte';
 	import SidebarCloseButton from '$lib/components/sidebar/SidebarCloseButton.svelte';
-	import { onMount } from 'svelte';
 	import focusSidebar from '$lib/stores/focusSidebar';
 	import { getUser } from '@lucia-auth/sveltekit/client';
+	import { browser } from '$app/environment';
 
 	export let tabindex: boolean;
 	let closeBtn: SidebarCloseButton;
 	const user = getUser();
 
-	onMount(() => {
-		const focusSidebarCloseButton = (e: KeyboardEvent) => {
-			if (e.key === 'Tab' && $focusSidebar) {
-				e.preventDefault();
-				if (closeBtn.focus) {
-					closeBtn.focus();
-				}
-				focusSidebar.set(false);
-			}
-		};
-		document.addEventListener('keydown', focusSidebarCloseButton);
-
-		return () => {
-			document.removeEventListener('keydown', focusSidebarCloseButton);
-		};
-	});
+	$: if (browser && $focusSidebar) {
+		closeBtn.focus();
+		focusSidebar.set(false);
+	}
 </script>
 
 <div class="sidebar">

--- a/tests/layout/layout.spec.ts
+++ b/tests/layout/layout.spec.ts
@@ -82,15 +82,6 @@ test.describe('layout small screen', () => {
 		await page.goto('/');
 	});
 
-	test('switch theme button switches themes', async ({ page }) => {
-		const locator = page.locator('html');
-		await page.locator('[aria-label="switch theme to dark"]').click();
-		await expect(locator).toHaveClass('dark');
-
-		await page.locator('[aria-label="switch theme to light"]').click();
-		await expect(locator).not.toHaveClass('dark');
-	});
-
 	test('menu button opens sidebar and sidebar close button closes sidebar', async ({ page }) => {
 		await page.locator('button:visible[aria-label="open sidebar"]').click();
 		const locator = page.locator('.main > .sidebar');
@@ -109,9 +100,8 @@ test.describe('layout small screen', () => {
 		await expect(locator).toHaveCSS('margin-left', '-256px');
 	});
 
-	test('pressing tab after opening sidebar focuses sidebar close button', async ({ page }) => {
+	test('opening sidebar focuses sidebar close button', async ({ page }) => {
 		await page.locator('button:visible[aria-label="open sidebar"]').click();
-		await page.keyboard.press('Tab');
 		const locator = page.locator('.sidebar button[aria-label="close sidebar"]');
 		await expect(locator).toBeFocused();
 	});


### PR DESCRIPTION
Closes #57 

Before this change, the browser would listen to the `tab` keydown event and focus the button even if the user clicks elsewhere or does something that should change focus of the button. 

This changes it so the button is immediately focused after opening the sidebar, so it can be unfocused by user actions.