### PR TITLE
Fix updating filters not reflecting in filters input UI

### DIFF
--- a/src/lib/components/form/series/filters/tags/SeriesFiltersTagInput.svelte
+++ b/src/lib/components/form/series/filters/tags/SeriesFiltersTagInput.svelte
@@ -49,6 +49,9 @@
 					handleRemove={() => {
 						handleRemoveTag(i);
 					}}
+					handleUpdate={() => {
+						$values = $values;
+					}}
 				/>
 			{:else}
 				<p class="text-sm italic">No tags selected</p>

--- a/src/lib/components/layout/db/DBShell.svelte
+++ b/src/lib/components/layout/db/DBShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import Keyed from '$lib/components/form/Keyed.svelte';
 	import SearchInput from '$lib/components/form/SearchInput.svelte';
 	import SubmitButton from '$lib/components/form/SubmitButton.svelte';
 	import PaginationContainer from '$lib/components/pagination/PaginationContainer.svelte';
@@ -54,7 +55,9 @@
 			<div class="flex flex-col gap-2">
 				<SearchInput {inputPlaceholder} ariaLabel={inputPlaceholder} />
 
-				{@render filters?.()}
+				<Keyed>
+					{@render filters?.()}
+				</Keyed>
 
 				<div class="flex gap-4">
 					<div class="w-fit">


### PR DESCRIPTION
The `data` prop in `+page.svelte` is not deeply reactive in Svelte 5, so updates to the filters were not reflected in the UI.
By wrapping the filters in a keyed block, it forces the component to re-render.